### PR TITLE
Clearfix mixin should contain margins

### DIFF
--- a/dist/utilities/_clearfix.scss
+++ b/dist/utilities/_clearfix.scss
@@ -13,6 +13,11 @@
 //    else in the document.
 // 2. Contain the the first child’s top margin. Ensures rendering is consistent
 //    with the other common clearfix method, `overflow: hidden`.
+//
+// Acknowledgements
+//
+// A new micro clearfix hack: [Nicolas Gallagher](http://nicolasgallagher.com/micro-clearfix-hack/)
+// Beat *that* clearfix: [Thierry Koblentz](http://www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.php)
 
 @mixin clearfix {
     &::before,
@@ -25,8 +30,3 @@
         clear: both;
     }
 }
-
-// Acknowledgements
-//
-// A new micro clearfix hack: [Nicolas Gallagher](http://nicolasgallagher.com/micro-clearfix-hack/)
-// Beat *that* clearfix: [Thierry Koblentz](http://www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.php)

--- a/test/index.html
+++ b/test/index.html
@@ -31,6 +31,32 @@
         <div class="reverse-deg-gradient block"></div>
     </div>
 
+    <h2>Clearfix test</h2>
+
+    <div class="example">
+        <p>This div should have floats with contained margins using the clearfix include</p>
+
+        <div class="clearfix wrapper">
+            <h1>Heading</h1>
+            <div class="block">
+            </div>
+            <div class="block">
+            </div>
+        </div>
+    </div>
+
+    <div class="example">
+        <p>This div should have floats with contained margins using overflow hidden</p>
+
+        <div class="overflow-hidden wrapper">
+            <h1>Heading</h1>
+            <div class="block">
+            </div>
+            <div class="block">
+            </div>
+        </div>
+    </div>
+
   </body>
 
 </html>

--- a/test/test.scss
+++ b/test/test.scss
@@ -84,3 +84,29 @@ $deg-gradient: linear-gradient(132deg, blue, red, purple);
 .reverse-deg-gradient {
     background: reverse-gradient($deg-gradient);
 }
+
+// Test function `clearfix`
+// --------------------------------
+
+.clearfix {
+    @include clearfix;
+    
+    border: 1px solid red;
+
+    .block {
+        float: left;
+        
+        margin: 20px;
+    }
+}
+
+.overflow-hidden {
+    overflow: hidden;
+    border: 1px solid red;
+
+    .block {
+        float: left;
+        
+        margin: 20px;
+    }
+}


### PR DESCRIPTION
There are two common “clearfix” hacks:
- Apply `overflow: hidden`. This creates a block formatting context which by definition contains floats, but also contains margins of child elements.
- Use a version of the “micro clearfix”, which uses generated content and the `clear` property.

The latter is what our `@mixin clearfix` does. However, the version we use doesn’t contain margins, so isn’t consistent with `overflow: hidden`. It’s a good idea to have the rendered result of both methods be consistent, so we should use the Nicolas Gallagher version (minus the stuff for old IE). 

Status: **Ready to merge**
Reviewers: @jeffkamo @kpeatt
## Changes
- Add a :before element to contain top margins of children
- Update comments (also simplified the example)
- Added a link to the Gallagher version
