### PR TITLE
Drop reference to $margin variable in tap-highlight mixin.

### DIFF
--- a/dist/utilities/_tap-highlight.scss
+++ b/dist/utilities/_tap-highlight.scss
@@ -42,7 +42,7 @@
     $color: rgba(0, 0, 0, 0.25),
     $overlay-position: before,
     $fast-tap-enabled: false,
-    $box-shadow-blur: $margin/2,
+    $box-shadow-blur: 5px,
     $active-selector: ':active'
 ) {
 


### PR DESCRIPTION
The tap-highlight mixin references `$margin` which doesn’t exist without Vellum. Since it’s dubious whether blur size should be linked to margin, this PR drops it, replacing it with a static `5px` (what the var from Vellum would compile to). Since it’s the default value for a param, this should be fine.

Status: **Ready to merge**

Reviewers: @kpeatt 
Ticket: Closes #13 
## Changes
- Replaces use of `$margin / 2` with `5px` in the `$box-shadow-blur` param to the `tap-highlight` mixin.
